### PR TITLE
[PRD-5303] Expose UI settings on Settings class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acquireweb/wayfinder-web-map-types",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acquireweb/wayfinder-web-map-types",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "devDependencies": {
         "color-types": "^1.0.0",
         "prettier": "^3.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acquireweb/wayfinder-web-map-types",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Type defintions for the Wayfinder Web Map API",
   "types": "index.d.ts",
   "scripts": {

--- a/types/Settings.d.ts
+++ b/types/Settings.d.ts
@@ -255,6 +255,8 @@ export class Settings {
   get useLowerQuality(): boolean;
 
   get latlong(): LatLong;
+
+  get ui(): null | UISettingsInput;
 }
 
 export type SettingsInput = null | Partial<{
@@ -308,3 +310,44 @@ export type SettingsInput = null | Partial<{
   /** map marker options */
   markers: Partial<MapMarkerSettings>;
 }>;
+
+/**
+ * Extracted from Web Map UI
+ * @see https://github.com/acquiredigital/wayfinder-web-map-ui/blob/54848e24c49bbc082bf38c88cf65f8f285311794/src/stores/settings.ts#L10
+ */
+type UISettingsInput =
+  | {
+      features?:
+        | {
+            floorSelector?: boolean | null | undefined;
+            zoomControls?: boolean | null | undefined;
+            currentLocation?: boolean | null | undefined;
+            routing?: boolean | null | undefined;
+            routingInfo?: boolean | null | undefined;
+            search?: boolean | null | undefined;
+            categories?: boolean | null | undefined;
+            amenities?: boolean | null | undefined;
+            suggestions?: boolean | null | undefined;
+          }
+        | null
+        | undefined;
+      behaviour?:
+        | {
+            zoomToDestination: boolean | null | undefined;
+            showEmptyCategories: boolean | null | undefined;
+            floorNamePreference: "long" | "short" | null | undefined;
+            alwaysShowFloors: boolean;
+            openingHoursPreference: "long" | "short" | null | undefined;
+            enableLinks: boolean | null | undefined;
+            soonDuration: number | null | undefined;
+            maxCategoriesTags: number | null | undefined;
+            dragHidesInfo: boolean | null | undefined;
+            zoomOnInitialLoad: boolean | null | undefined;
+            distanceUnits: "meters" | "yards" | null | undefined;
+            timeFormat: "12h" | "24h" | null | undefined;
+          }
+        | null
+        | undefined;
+    }
+  | null
+  | undefined;


### PR DESCRIPTION
## Useful links

*Please include any links to tickets, companion branches, pull requests and preview environments if required*

***Ticket***:  https://app.clickup.com/t/2561453/PRD-5303

***Branch***: `feat/PRD-5303_add-web-map-settings-to-cms`

***Related***:
- https://github.com/acquiredigital/wayfinder-web-map-ui/pull/38
- https://github.com/acquiredigital/wayfinder-web-map-api/pull/66
- https://github.com/acquiredigital/wayfinder-api/pull/374

## Description

*Please include the ticket description and a brief summary of how you made the change*


Add the new `ui` getter on the settings class. 

Updated the docs: https://app.clickup.com/2561453/v/dc/2e5dd-10408/2e5dd-19348

## Checklist

*Please ensure the following points are true before submitting a PR*

- [x] My branch is named in the correct format
- [x] My pull request contains the ClickUp ticket reference in its title
- [x] My code follows the style guidelines of this project
- [x] No TODOs, commented out code, console logs, etc. exist in my pull request
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have added any new API routes created to the relevant Insomnia Collection where appropriate
- [x] I have updated any associated product documentation where appropriate
